### PR TITLE
feat: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+examples
+screenshots
+*.test.js


### PR DESCRIPTION
This PR aimed to reduce the bundle size by removing examples, screenshots, and tests from it.
Currently, the bundle size is 1.5MB
After adding `.npmignore`, the bundle size is 16.4 kB